### PR TITLE
Stylistic changes:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Cargo.lock
 
 # Vi swp files
 *.swp
+*.swo
 
 # Emacs files
 *~

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,5 +2,4 @@ mod nfa;
 
 fn main() {
     println!("Hello, world!");
-    
 }

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -120,23 +120,17 @@ pub fn star(nfa: &NFA) -> NFA {
         finished.insert(Node(n));
     });
     let mut delta = nfa.delta.clone();
-    for &(Node(n), ch) in nfa.delta.keys() {
-        let mapped = nfa.delta.get(&(Node(n), ch));
-        match mapped {
-            Some(set) => {
-                let mut new_set = set.clone();
-                let added_starting = false;
-                for &Node(m) in set.iter() {
-                    if nfa.finished.contains(&Node(m)) && !added_starting {
-                        for &Node(p) in nfa.starting.iter() {
-                            new_set.insert(Node(p));
-                        }
-                    }
+    for (&(Node(n), ch), set) in nfa.delta.iter() {
+        let mut new_set = set.clone();
+        let added_starting = false;
+        for &Node(m) in set.iter() {
+            if nfa.finished.contains(&Node(m)) && !added_starting {
+                for &Node(p) in nfa.starting.iter() {
+                    new_set.insert(Node(p));
                 }
-                delta.insert((Node(n), ch), new_set);
             }
-            _ => {}
         }
+        delta.insert((Node(n), ch), new_set);
     }
     NFA {
         states: nfa.states,


### PR DESCRIPTION
 - used rustfmt
 - made some expressions more concise
    * replaced `match`s with methods
    * used `for` instead of `while let` when possible
    * used shorter array `.into()` for `HashSet` and `HashMap` literals